### PR TITLE
Fix fixed size of Overview SplFixedArray

### DIFF
--- a/src/Command/OverviewCommand.php
+++ b/src/Command/OverviewCommand.php
@@ -39,7 +39,7 @@ abstract class OverviewCommand extends Command implements CommandInterface
         $this->to = $to;
         $this->format = array_merge(array('number' => false), $format);
 
-        parent::__construct(new \SplFixedArray($this->to - $this->from), true);
+        parent::__construct(new \SplFixedArray($this->to - $this->from + 1), true);
     }
 
     /**

--- a/tests/Command/XoverCommandTest.php
+++ b/tests/Command/XoverCommandTest.php
@@ -25,7 +25,7 @@ class XoverCommandTest extends CommandTest
     public function testItHasDefaultResult()
     {
         $command = $this->createCommandInstance();
-        $this->assertCount(10, $command->getResult());
+        $this->assertCount(11, $command->getResult());
     }
 
     public function testItReturnsStringWhenExecuting()
@@ -53,7 +53,7 @@ class XoverCommandTest extends CommandTest
         $command->onOverviewInformationFollows($response);
 
         $result = $command->getResult();
-        $this->assertCount(10, $result);
+        $this->assertCount(11, $result);
 
         $result->rewind();
         $article = $result->current();

--- a/tests/Command/XzverCommandTest.php
+++ b/tests/Command/XzverCommandTest.php
@@ -25,7 +25,7 @@ class XzverCommandTest extends CommandTest
     public function testItHasDefaultResult()
     {
         $command = $this->createCommandInstance();
-        $this->assertCount(10, $command->getResult());
+        $this->assertCount(11, $command->getResult());
     }
 
     public function testItReturnsStringWhenExecuting()
@@ -53,7 +53,7 @@ class XzverCommandTest extends CommandTest
         $command->onOverviewInformationFollows($response);
 
         $result = $command->getResult();
-        $this->assertCount(10, $result);
+        $this->assertCount(11, $result);
 
         $result->rewind();
         $article = $result->current();


### PR DESCRIPTION
If we get results from 1 to 500 that's actually 500 results, not 499. Throws an index out of range exception at the moment