### PR TITLE
Fix messages being truncated

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -164,7 +164,7 @@ class Connection implements ConnectionInterface
         while (!feof($this->socket)) {
             $buffer .= @fgets($this->socket, 1024);
 
-            if (".\r\n" === substr($buffer, -3)) {
+            if ("\n.\r\n" === substr($buffer, -4)) {
                 break;
             }
 


### PR DESCRIPTION
You're currently stopping the stream when encountering `.\r\n` but this means such a message:

```
Hi,

I like pasta.

My regards
.
```

Would get truncated at `pasta`. This makes sure we're looking for the actual end of message period (alone on a new line) instead of any period that is at the end of a line.

---

Closes #13 