### PR TITLE
Preserve empty lines in the response

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -159,7 +159,7 @@ class Connection implements ConnectionInterface
 
             // Check if the line terminates the text response.
             if ($line === '.') {
-                return new MultiLineResponse($response, array_filter($lines));
+                return new MultiLineResponse($response, $lines);
             }
 
             // If 1st char is '.' it's doubled (NNTP/RFC977 2.4.1).


### PR DESCRIPTION
Fixes #31 

Without empty lines the responses are invalid and cannot be parsed by mime parsers.